### PR TITLE
Add pixelated number favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#111"/>
+  <rect x="4" y="4" width="4" height="4" fill="#eeeeee"/>
+  <rect x="4" y="8" width="4" height="4" fill="#eeeeee"/>
+  <rect x="4" y="12" width="4" height="4" fill="#eeeeee"/>
+  <rect x="4" y="16" width="4" height="4" fill="#eeeeee"/>
+  <rect x="4" y="20" width="4" height="4" fill="#eeeeee"/>
+  <rect x="0" y="20" width="4" height="4" fill="#eeeeee"/>
+  <rect x="12" y="4" width="4" height="4" fill="#eeeeee"/>
+  <rect x="16" y="4" width="4" height="4" fill="#eeeeee"/>
+  <rect x="16" y="8" width="4" height="4" fill="#eeeeee"/>
+  <rect x="12" y="12" width="4" height="4" fill="#eeeeee"/>
+  <rect x="16" y="12" width="4" height="4" fill="#eeeeee"/>
+  <rect x="12" y="16" width="4" height="4" fill="#eeeeee"/>
+  <rect x="12" y="20" width="4" height="4" fill="#eeeeee"/>
+  <rect x="16" y="20" width="4" height="4" fill="#eeeeee"/>
+  <rect x="24" y="4" width="4" height="4" fill="#eeeeee"/>
+  <rect x="28" y="4" width="4" height="4" fill="#eeeeee"/>
+  <rect x="28" y="12" width="4" height="4" fill="#eeeeee"/>
+  <rect x="24" y="12" width="4" height="4" fill="#eeeeee"/>
+  <rect x="28" y="20" width="4" height="4" fill="#eeeeee"/>
+  <rect x="24" y="20" width="4" height="4" fill="#eeeeee"/>
+  <rect x="28" y="8" width="4" height="4" fill="#eeeeee"/>
+  <rect x="28" y="16" width="4" height="4" fill="#eeeeee"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
           content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
   />
   <title>Quick Random Tiles</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <!-- Google Font -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- add dark themed pixelated numbers favicon
- reference favicon in HTML head for GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ded1fdf48320b090b610320e6fbf