### PR TITLE
Fix PWA start URL for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
   />
   <title>Quick Random Tiles</title>
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <meta name="theme-color" content="#171c26" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
   <!-- Google Font -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Quick Random Tiles",
+  "short_name": "Random Tiles",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#171c26",
+  "theme_color": "#171c26",
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- ensure PWA manifest uses relative start URL and scope so installed app opens the correct page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e3a14b50832082795985848fc8cf