### PR TITLE
Add dedicated mobile app icon

### DIFF
--- a/app-icon.svg
+++ b/app-icon.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#1a202d"/>
+  <g fill="#e2e8f0">
+    <rect x="52" y="52" width="120" height="120" rx="28"/>
+    <rect x="196" y="52" width="120" height="120" rx="28"/>
+    <rect x="340" y="52" width="120" height="120" rx="28"/>
+
+    <rect x="52" y="196" width="120" height="120" rx="28"/>
+    <rect x="196" y="196" width="120" height="120" rx="28"/>
+    <rect x="340" y="196" width="120" height="120" rx="28"/>
+
+    <rect x="52" y="340" width="120" height="120" rx="28"/>
+    <rect x="196" y="340" width="120" height="120" rx="28"/>
+    <rect x="340" y="340" width="120" height="120" rx="28"/>
+  </g>
+  <g fill="#1a202d" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="88"
+     text-anchor="middle" dominant-baseline="middle">
+    <text x="112" y="112">1</text>
+    <text x="256" y="112">2</text>
+    <text x="400" y="112">3</text>
+
+    <text x="112" y="256">4</text>
+    <text x="256" y="256">5</text>
+    <text x="400" y="256">6</text>
+
+    <text x="112" y="400">7</text>
+    <text x="256" y="400">8</text>
+    <text x="400" y="400">9</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   />
   <title>Quick Random Tiles</title>
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="apple-touch-icon" href="app-icon.svg" />
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="theme-color" content="#171c26" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -8,10 +8,15 @@
   "theme_color": "#171c26",
   "icons": [
     {
-      "src": "favicon.svg",
-      "sizes": "any",
+      "src": "app-icon.svg",
+      "sizes": "512x512",
       "type": "image/svg+xml",
       "purpose": "any maskable"
+    },
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a dedicated 512x512 SVG app icon that displays the numbers 1-9 in a 3x3 grid to match the favicon style
- reference the new icon from the PWA manifest and as the apple touch icon for mobile installs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daa815c28083209b114271205706b9